### PR TITLE
🛟 Arrumador: Configure tooling and GitHub Action CI

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -1,0 +1,65 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v2
+
+      - name: Install dependencies
+        run: mise run install
+
+      - name: Codegen
+        run: mise run codegen
+
+      - name: Check for differences
+        id: check_diff
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create Pull Request if differences exist
+        if: steps.check_diff.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore: update codegen"
+          title: "chore: update codegen"
+          body: "Automated PR to update codegen."
+          branch: "chore/update-codegen"
+
+      - name: Run CI
+        run: mise run ci
+
+      - name: Release
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag_name="${GITHUB_REF#refs/tags/}"
+          if [[ "$github.event_name" == 'workflow_dispatch' ]]; then
+             tag_name="manual-${GITHUB_RUN_ID}"
+          fi
+          gh release create "$tag_name" --title "Release $tag_name" --generate-notes
+
+      - name: Upload Artifacts
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts
+          path: |
+            index.html

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,40 @@
+[tools]
+"github:lucasew/workspaced" = "0.2.3"
+
+[tasks]
+lint = "workspaced codebase lint"
+fmt = "workspaced codebase format"
+
+[tasks.test]
+depends = ["test:*"]
+
+[tasks.codegen]
+depends = ["codegen:*"]
+
+[tasks.install]
+depends = ["install:*"]
+
+[tasks.ci]
+depends = ["lint", "test"]
+
+[tasks."test:dummy"]
+run = "echo 'No tests yet'"
+
+[tasks."install:smart"]
+run = '''
+#!/usr/bin/env bash
+if [ -f "package-lock.json" ]; then
+  npm ci
+elif [ -f "yarn.lock" ]; then
+  yarn install --frozen-lockfile
+elif [ -f "pnpm-lock.yaml" ]; then
+  pnpm install --frozen-lockfile
+elif [ -f "bun.lockb" ]; then
+  bun install --frozen-lockfile
+else
+  echo "No recognized package manager lockfile found. Skipping install."
+fi
+'''
+
+[tasks."codegen:dummy"]
+run = "echo 'No codegen steps yet'"


### PR DESCRIPTION
Assumptions:
- Expected package managers are either `npm`, `yarn`, `pnpm`, or `bun`. Detection script implemented to figure out which one is active in `mise run install:*`.
- No existing tests or explicit codegen routines present, gracefully defaulting via wildcard fallback tasks in `mise.toml`.

Alternatives Not Chosen:
- Individual linter setup: strictly omitted in favor of universal `workspaced` deployment per agent instructions.
- Modifying actual JavaScript source code (`index.html`) to pass the lint checks: omitted, as the scope of this PR is only tool configuration.

How To Pivot:
- If `workspaced` is incompatible or undesirable in its current version, adjust the `github:lucasew/workspaced` version tag in `mise.toml`.
- If a custom codegen workflow is established later, implement the actual generation commands within `[tasks."codegen:actual"]` to automatically trigger as part of the wildcard sequence.

Next Knobs:
- `.github/workflows/autorelease.yml`: To disable conditional PR generation for codegen updates, remove or comment out the `Check for differences` and `Create Pull Request` action steps.
- `mise.toml`: If specific test runners are added (e.g., vitest, jest), attach them via `[tasks."test:unit"]` or equivalent to automatically be picked up by the `ci` task dependency.

---
*PR created automatically by Jules for task [8292081598130482125](https://jules.google.com/task/8292081598130482125) started by @lucasew*