### PR TITLE
🧹 Janitor: Fix formatting for README and renovate.json

### DIFF
--- a/.jules/janitor.md
+++ b/.jules/janitor.md
@@ -1,0 +1,1 @@
+- 2025-03-25: Always enforce formatting with standard linters across HTML, JS, and JSON files to maintain consistent project style.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # seletor-de-foto ([demo](https://seletor-de-foto.vercel.app/))
+
 Te ajuda a escolher qual foto postar/mandar
 
 - Usa o random.org para maior precisão de aleatoriedade podendo usar o `Math.random` se não conseguir.

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended",
-    "github>lewtec/renovate-config:base"
-  ]
+  "extends": ["config:recommended", "github>lewtec/renovate-config:base"]
 }


### PR DESCRIPTION
### What Changed
- Formatted `README.md` to have proper spacing after the title.
- Formatted `renovate.json` arrays into a single line.
- Initialized the Janitor journal `.jules/janitor.md` with a reusable insight.

### Why This Helps
Enforces baseline standard formatting on peripheral configuration and documentation files without conflicting with active heavy Refactor/Arrumador PRs touching `index.html`.

### Before/After
- **Before:** `renovate.json` extends array was multi-line. `README.md` lacked line spacing after the title.
- **After:** `renovate.json` extends array is single-line. `README.md` is properly spaced. `.jules/janitor.md` is initialized.

### Verification
Ran `mise run trunk fmt` effectively formatting the subset of non-contested files.

---

### Assumptions
- I assumed formatting `index.html` would cause severe merge conflicts with PRs #5 and #6, thus leaving it out.
- I assumed `renovate.json` and `README.md` are stable enough to be formatted without risk of conflict.
- I assumed configuring CI tooling directly was Arrumador's job (PR #8), so I left `trunk` out of the final diff.

### Alternatives Not Chosen
- Formatting `index.html` and setting up Trunk configuration locally, which was dismissed to avoid merge conflicts and scope creep.

### How To Pivot
- If `index.html` formatting is desired regardless of PRs #5 and #6, checkout `index.html` and format it with Prettier/Trunk.

### Next Knobs
- **Files to format:** `index.html` can be added to the formatting check once refactoring PRs are merged.
- **Linters:** Additional linters can be added to `trunk.yaml` (by Arrumador) as the project scales.

---
*PR created automatically by Jules for task [2689140690561138597](https://jules.google.com/task/2689140690561138597) started by @lucasew*